### PR TITLE
fix:migrationファイルの修正

### DIFF
--- a/database/migrations/2022_10_08_062233_create_comments_table.php
+++ b/database/migrations/2022_10_08_062233_create_comments_table.php
@@ -12,7 +12,7 @@ class CreateCommentsTable extends Migration
             $table->increments('id');
             $table->string('title', 30);
             $table->string('body', 300);
-            $table->integer('rating');
+            $table->tinyInteger('rating');
             $table->timestamps();
             $table->softDeletes();
             $table->integer('snack_id')->unsigned();

--- a/database/migrations/2022_10_08_065954_create_snack_store_table.php
+++ b/database/migrations/2022_10_08_065954_create_snack_store_table.php
@@ -11,7 +11,6 @@ class CreateSnackStoreTable extends Migration
         Schema::create('snack_store', function (Blueprint $table) {
             $table->integer('snack_id')->unsigned();
             $table->integer('store_id')->unsigned();
-            /* この次のコードが必要か分からない。 */
             $table->primary(['snack_id', 'store_id']);
         });
     }

--- a/database/migrations/2022_10_08_073356_create_snack_user_table.php
+++ b/database/migrations/2022_10_08_073356_create_snack_user_table.php
@@ -11,7 +11,6 @@ class CreateSnackUserTable extends Migration
         Schema::create('snack_user', function (Blueprint $table) {
             $table->integer('snack_id')->unsigned();
             $table->integer('user_id')->unsigned();
-            /* この次のコードが必要か分からない。 */
             $table->primary(['snack_id', 'user_id']);
         });
     }

--- a/database/migrations/2022_10_08_073647_create_comment_user_table.php
+++ b/database/migrations/2022_10_08_073647_create_comment_user_table.php
@@ -11,7 +11,6 @@ class CreateCommentUserTable extends Migration
         Schema::create('comment_user', function (Blueprint $table) {
             $table->integer('comment_id')->unsigned();
             $table->integer('user_id')->unsigned();
-            /* この次のコードが必要か分からない。 */
             $table->primary(['comment_id', 'user_id']);
         });
     }

--- a/database/migrations/2022_10_08_074147_create_images_table.php
+++ b/database/migrations/2022_10_08_074147_create_images_table.php
@@ -9,8 +9,8 @@ class CreateImagesTable extends Migration
     public function up()
     {
         Schema::create('images', function (Blueprint $table) {
-            /* 下記laravel参照 */
-            $table->integer('id');
+            /* 下記laravel公式ブックのポリモーフィック参照 */
+            $table->increments('id');
             $table->string('image_path', 200);
             $table->integer('imageable_id');
             $table->string('imageable_type');


### PR DESCRIPTION
ratingの値は小さいため型を'integer'から'tinyInteger'に変更。
多対多のテーブルにおいては,どれが主キーか設定させるためprimary([]);の型を使用。
ポリモーフィックリレーションにおける中間テーブルには主キーが必要となるため、
型をintegerからincrementsに変更。